### PR TITLE
feat: Add an acl template function for permission checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Test case for certificate PEM loading in PKCS1 module
 * Regression tests for session GC and translate_result fixes in REST plugin
 * New `DEBUG_SQL` configuration option (default `True`) to control debug-level SQL query logging in MySQL, SQLite, and PostgreSQL engine plugins
+* Tests covering session ACL validation and the ACL template predicates in the MVC utilities
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Service polling in `service_utils` now auto-selects the best available mechanism: `epoll` on Linux, `kqueue` on BSD/macOS, `poll` on other Unix systems, and `select` as fallback
 * Implemented `EpollPolling` using `select.epoll()`, `KqueuePolling` using `select.kqueue()`, and `Epoll2Polling` using `select.poll()` as alternatives to `SelectPolling`, removing the 1024 file descriptor limit on supported platforms
 * Client I/O polling in `client_utils` now uses the same platform-aware strategy via a new `poll_socket()` function, replacing direct `select.select()` calls in `_receive()` and `_send()` and removing the 1024 fd limit for epoll/kqueue/poll backends while preserving the guard for the `select` fallback
+* Replaced short-circuit conditional clauses with explicit conditional statements in the MVC utilities for better readability
 
 ### Fixed
 

--- a/mvc/src/mvc_utils/controller.py
+++ b/mvc/src/mvc_utils/controller.py
@@ -5977,19 +5977,14 @@ def get_process_method(controller, request, process_method_name):
         else:
             attribute_session_attribute_value = DEFAULT_SESSION_ATTRIBUTE
 
-        # retrieves the user ACL value
-        user_acl = (
-            controller.get_session_attribute(request, attribute_session_attribute_value)
-            or {}
+        # sets the initial accept node value by validating the
+        # session ACL against the permission key and value
+        accept_node = controller.validate_acl_session(
+            request,
+            attribute_permission_value,
+            value=attribute_value_value,
+            session_attribute=attribute_session_attribute_value,
         )
-
-        # process the ACL values, retrieving the permissions value
-        permissions = controller.process_acl_values(
-            (user_acl,), attribute_permission_value
-        )
-
-        # sets the initial accept node value
-        accept_node = permissions <= attribute_value_value
 
         # in case the visit child is set
         if self.visit_childs:
@@ -6042,19 +6037,14 @@ def get_process_method(controller, request, process_method_name):
         else:
             attribute_session_attribute_value = DEFAULT_SESSION_ATTRIBUTE
 
-        # retrieves the user ACL value
-        user_acl = (
-            controller.get_session_attribute(request, attribute_session_attribute_value)
-            or {}
+        # sets the initial accept node value by validating the
+        # session ACL against the permission key and value
+        accept_node = controller.validate_acl_session(
+            request,
+            attribute_permission_value,
+            value=attribute_value_value,
+            session_attribute=attribute_session_attribute_value,
         )
-
-        # process the ACL values, retrieving the permissions value
-        permissions = controller.process_acl_values(
-            (user_acl,), attribute_permission_value
-        )
-
-        # sets the initial accept node value
-        accept_node = permissions <= attribute_value_value
 
         # in case the visit child is set
         if self.visit_childs:
@@ -6111,19 +6101,14 @@ def get_process_method(controller, request, process_method_name):
         else:
             attribute_session_attribute_value = DEFAULT_SESSION_ATTRIBUTE
 
-        # retrieves the user ACL value
-        user_acl = (
-            controller.get_session_attribute(request, attribute_session_attribute_value)
-            or {}
+        # sets the initial accept node value by negating the validation
+        # of the session ACL against the permission key and value
+        accept_node = not controller.validate_acl_session(
+            request,
+            attribute_permission_value,
+            value=attribute_value_value,
+            session_attribute=attribute_session_attribute_value,
         )
-
-        # process the ACL values, retrieving the permissions value
-        permissions = controller.process_acl_values(
-            (user_acl,), attribute_permission_value
-        )
-
-        # sets the initial accept node value
-        accept_node = permissions > attribute_value_value
 
         # in case the visit child is set
         if self.visit_childs:

--- a/mvc/src/mvc_utils/controller.py
+++ b/mvc/src/mvc_utils/controller.py
@@ -793,21 +793,20 @@ def save_entity_relations(
             # adds the relation entity to the list
             # in case the entity was created and the
             # relation in meant to be associated
-            relation_entity and associate_relation and relation_entities.append(
-                relation_entity
-            )
+            if relation_entity and associate_relation:
+                relation_entities.append(relation_entity)
 
         # adds an error to the relation name in case
         # the validation in one of its entities failed
-        relation_validation_failed and entity.add_error(
-            relation_name, "relation validation failed"
-        )
+        if relation_validation_failed:
+            entity.add_error(relation_name, "relation validation failed")
 
         # in case it is a to one relation
         if relation_type == 1:
             # sets the relation entity in the entity, only
             # in case the associate relation flag is set
-            associate_relation and setattr(entity, relation_name, relation_entity)
+            if associate_relation:
+                setattr(entity, relation_name, relation_entity)
         # in case it is a to many relation
         else:
             # sets the relation entities in the entity
@@ -3012,9 +3011,7 @@ def process_template_file(self, request, template_file, variable_encoding=None):
     # assigns it to the template file so that it may be called using
     # the function call syntax (eg: acl("entity.action"))
     def acl(name, value=DEFAULT_VALUE_ATTRIBUTE):
-        user_acl = self.get_session_attribute(request, DEFAULT_SESSION_ATTRIBUTE) or {}
-        permissions = self.process_acl_values((user_acl,), name)
-        return permissions <= value
+        return self.validate_acl_session(request, name, value=value)
 
     template_file.assign("acl", acl)
 
@@ -3123,12 +3120,14 @@ def retrieve_template_file(
     # retrieves the global bundle for the locale and adds it to the
     # template file in case it's a valid bundle (successful retrieval)
     global_bundle = self._get_bundle(locale)
-    global_bundle and template_file.add_bundle(global_bundle)
+    if global_bundle:
+        template_file.add_bundle(global_bundle)
 
     # tries to gather the countries locale bundle and in case it's found
     # adds it to the current template file (default operation)
     countries_bundle = self._get_bundle(locale, bundle_name="countries")
-    countries_bundle and template_file.add_bundle(countries_bundle)
+    if countries_bundle:
+        template_file.add_bundle(countries_bundle)
 
     # iterates over the complete set of extra arguments provided in the
     # proper dictionary and assigns each of these values to the proper
@@ -3556,7 +3555,8 @@ def get_session_attribute(
 
     # in case the unset the session attribute flag is set
     # the session attribute is unset
-    unset_session_attribute and request_session.unset_attribute(session_attribute_name)
+    if unset_session_attribute:
+        request_session.unset_attribute(session_attribute_name)
 
     # returns the session attribute to the caller method as expected
     # by the current infra-structure
@@ -4295,7 +4295,8 @@ def set_resources_path(self, resources_path, update_resources=True, parameters={
 
     # in case the update resources flag is set (the updating
     # of the resources path uses the parameters)
-    update_resources and self.update_resources_path(parameters)
+    if update_resources:
+        self.update_resources_path(parameters)
 
 
 def get_extras_path(self):
@@ -6005,7 +6006,8 @@ def get_process_method(controller, request, process_method_name):
 
                 # in case the accept node flag is set
                 # accepts the node child node
-                accept_node and node.accept(self)
+                if accept_node:
+                    node.accept(self)
 
     def __process_ifaclp(self, node):
         # retrieves the attributes map
@@ -6069,7 +6071,8 @@ def get_process_method(controller, request, process_method_name):
 
                 # in case the accept node flag is set
                 # accepts the node child node
-                accept_node and node.accept(self)
+                if accept_node:
+                    node.accept(self)
 
     def __process_ifnotacl(self, node):
         # retrieves the attributes map
@@ -6137,7 +6140,8 @@ def get_process_method(controller, request, process_method_name):
 
                 # in case the accept node flag is set
                 # accepts the node child node
-                accept_node and node.accept(self)
+                if accept_node:
+                    node.accept(self)
 
     def __process_request_time(self, node):
         # retrieves the current time to be able to calculate

--- a/mvc/src/mvc_utils/controller.py
+++ b/mvc/src/mvc_utils/controller.py
@@ -3006,6 +3006,17 @@ def process_template_file(self, request, template_file, variable_encoding=None):
     # they may be used for "extra" composite operations
     template_file.attach_process_methods(process_methods_list)
 
+    # creates the ACL verification function, closed over the current
+    # request, that verifies if the session ACL holds the permission
+    # with the provided name (equivalent to the ifacl operation) and
+    # assigns it to the template file so that it may be called using
+    # the function call syntax (eg: acl("entity.action"))
+    def acl(name, value=DEFAULT_VALUE_ATTRIBUTE):
+        user_acl = self.get_session_attribute(request, DEFAULT_SESSION_ATTRIBUTE) or {}
+        permissions = self.process_acl_values((user_acl,), name)
+        return permissions <= value
+    template_file.assign("acl", acl)
+
     # processes the template file, returning the resulting
     # contents to the caller function, the returning value
     # should be a string containing the results

--- a/mvc/src/mvc_utils/controller.py
+++ b/mvc/src/mvc_utils/controller.py
@@ -3015,6 +3015,7 @@ def process_template_file(self, request, template_file, variable_encoding=None):
         user_acl = self.get_session_attribute(request, DEFAULT_SESSION_ATTRIBUTE) or {}
         permissions = self.process_acl_values((user_acl,), name)
         return permissions <= value
+
     template_file.assign("acl", acl)
 
     # processes the template file, returning the resulting

--- a/mvc/src/mvc_utils/mocks.py
+++ b/mvc/src/mvc_utils/mocks.py
@@ -84,3 +84,38 @@ class MockValidatedControllerNoHandler(object):
 
     def validate(self, request, parameters, validation_parameters):
         return self._validate_reasons
+
+
+class MockTemplateFile(object):
+    def __init__(self):
+        self.assigns = {}
+        self.process_methods_list = []
+        self.variable_encoding = None
+
+    def set_variable_encoding(self, variable_encoding):
+        self.variable_encoding = variable_encoding
+
+    def attach_process_methods(self, process_methods_list):
+        self.process_methods_list = process_methods_list
+
+    def assign(self, name, value):
+        self.assigns[name] = value
+
+    def process(self):
+        return "processed"
+
+
+class MockTemplateController(object):
+    def __init__(self, user_acl=None):
+        self._user_acl = user_acl
+
+    def get_process_method(self, request, method_name):
+        return None
+
+    def get_session_attribute(self, request, session_attribute_name):
+        return self._user_acl
+
+    def process_acl_values(self, acl_list, key):
+        from . import controller
+
+        return controller.process_acl_values(self, acl_list, key)

--- a/mvc/src/mvc_utils/mocks.py
+++ b/mvc/src/mvc_utils/mocks.py
@@ -28,6 +28,8 @@ __copyright__ = "Copyright (c) 2008-2024 Hive Solutions Lda."
 __license__ = "Apache License, Version 2.0"
 """ The license for the module """
 
+from . import controller
+
 
 class MockPlugin(object):
     def __init__(self):
@@ -108,14 +110,56 @@ class MockTemplateFile(object):
 class MockTemplateController(object):
     def __init__(self, user_acl=None):
         self._user_acl = user_acl
+        self._session_attribute_names = []
 
     def get_process_method(self, request, method_name):
         return None
 
     def get_session_attribute(self, request, session_attribute_name):
+        self._session_attribute_names.append(session_attribute_name)
         return self._user_acl
 
-    def process_acl_values(self, acl_list, key):
-        from . import controller
+    def process_acl_values(
+        self, acl_list, key, wildcard_value="*", maximum_value=10000
+    ):
+        return controller.process_acl_values(
+            self,
+            acl_list,
+            key,
+            wildcard_value=wildcard_value,
+            maximum_value=maximum_value,
+        )
 
-        return controller.process_acl_values(self, acl_list, key)
+    def validate_acl_session(
+        self, request, key, value=10, session_attribute="user_acl"
+    ):
+        return controller.validate_acl_session(
+            self, request, key, value=value, session_attribute=session_attribute
+        )
+
+
+class MockTemplateNode(object):
+    def __init__(self, attributes=None, children=None):
+        self.attributes = attributes or {}
+        self.children = children or []
+        self.accepted = False
+
+    def get_attributes(self):
+        return self.attributes
+
+    def accept(self, visitor):
+        self.accepted = True
+
+
+class MockTemplateVisitor(object):
+    def __init__(self, visit_childs=True):
+        self.visit_childs = visit_childs
+
+    def get_value(self, value):
+        return value
+
+    def get_literal_value(self, value):
+        return value
+
+    def _validate_accept_node(self, node, accept_node):
+        return accept_node

--- a/mvc/src/mvc_utils/test.py
+++ b/mvc/src/mvc_utils/test.py
@@ -48,7 +48,9 @@ class MVCUtilsTest(colony.Test):
             MVCUtilsBaseTestCase,
             RawModelTestCase,
             ValidatedDecoratorTestCase,
+            ValidateACLSessionTestCase,
             TemplateFileACLTestCase,
+            TemplateProcessMethodsTestCase,
             ExceptionsTestCase,
         )
 
@@ -329,6 +331,91 @@ class ValidatedDecoratorTestCase(colony.ColonyTestCase):
         self.assertEqual(my_action.__name__, "my_action")
 
 
+class ValidateACLSessionTestCase(colony.ColonyTestCase):
+    @staticmethod
+    def get_description():
+        return "Validate ACL Session test case"
+
+    def test_validate_acl_session(self):
+        controller_mock = mocks.MockTemplateController(user_acl={"entity.action": 10})
+        request = mocks.MockRequest()
+
+        result = controller.validate_acl_session(
+            controller_mock, request, "entity.action"
+        )
+        self.assertEqual(result, True)
+
+        result = controller.validate_acl_session(
+            controller_mock, request, "entity.other"
+        )
+        self.assertEqual(result, False)
+
+    def test_validate_acl_session_value(self):
+        controller_mock = mocks.MockTemplateController(user_acl={"entity.action": 20})
+        request = mocks.MockRequest()
+
+        result = controller.validate_acl_session(
+            controller_mock, request, "entity.action"
+        )
+        self.assertEqual(result, False)
+
+        result = controller.validate_acl_session(
+            controller_mock, request, "entity.action", value=20
+        )
+        self.assertEqual(result, True)
+
+    def test_validate_acl_session_wildcard(self):
+        controller_mock = mocks.MockTemplateController(user_acl={"*": 10})
+        request = mocks.MockRequest()
+
+        result = controller.validate_acl_session(
+            controller_mock, request, "entity.action"
+        )
+        self.assertEqual(result, True)
+
+        result = controller.validate_acl_session(
+            controller_mock, request, "other.action"
+        )
+        self.assertEqual(result, True)
+
+    def test_validate_acl_session_key_list(self):
+        controller_mock = mocks.MockTemplateController(user_acl={"entity.action": 10})
+        request = mocks.MockRequest()
+
+        result = controller.validate_acl_session(
+            controller_mock, request, ["entity.other", "entity.action"]
+        )
+        self.assertEqual(result, True)
+
+        result = controller.validate_acl_session(
+            controller_mock, request, ["entity.other", "entity.extra"]
+        )
+        self.assertEqual(result, False)
+
+    def test_validate_acl_session_session_attribute(self):
+        controller_mock = mocks.MockTemplateController(user_acl={"entity.action": 10})
+        request = mocks.MockRequest()
+
+        controller.validate_acl_session(controller_mock, request, "entity.action")
+        self.assertEqual(controller_mock._session_attribute_names, ["user_acl"])
+
+        controller.validate_acl_session(
+            controller_mock, request, "entity.action", session_attribute="admin_acl"
+        )
+        self.assertEqual(
+            controller_mock._session_attribute_names, ["user_acl", "admin_acl"]
+        )
+
+    def test_validate_acl_session_no_session(self):
+        controller_mock = mocks.MockTemplateController(user_acl=None)
+        request = mocks.MockRequest()
+
+        result = controller.validate_acl_session(
+            controller_mock, request, "entity.action"
+        )
+        self.assertEqual(result, False)
+
+
 class TemplateFileACLTestCase(colony.ColonyTestCase):
     @staticmethod
     def get_description():
@@ -391,6 +478,169 @@ class TemplateFileACLTestCase(colony.ColonyTestCase):
 
         acl = template_file.assigns["acl"]
         self.assertEqual(acl("entity.action"), False)
+
+
+class TemplateProcessMethodsTestCase(colony.ColonyTestCase):
+    @staticmethod
+    def get_description():
+        return "Template Process Methods test case"
+
+    def test_process_ifacl(self):
+        controller_mock = mocks.MockTemplateController(user_acl={"entity.action": 10})
+        request = mocks.MockRequest()
+        visitor = mocks.MockTemplateVisitor()
+        child_node = mocks.MockTemplateNode()
+        node = mocks.MockTemplateNode(
+            attributes={"permission": "entity.action"}, children=[child_node]
+        )
+
+        process_method = controller.get_process_method(
+            controller_mock, request, "process_ifacl"
+        )
+        process_method(visitor, node)
+
+        self.assertEqual(child_node.accepted, True)
+
+    def test_process_ifacl_denied(self):
+        controller_mock = mocks.MockTemplateController(user_acl={"entity.action": 10})
+        request = mocks.MockRequest()
+        visitor = mocks.MockTemplateVisitor()
+        child_node = mocks.MockTemplateNode()
+        node = mocks.MockTemplateNode(
+            attributes={"permission": "entity.other"}, children=[child_node]
+        )
+
+        process_method = controller.get_process_method(
+            controller_mock, request, "process_ifacl"
+        )
+        process_method(visitor, node)
+
+        self.assertEqual(child_node.accepted, False)
+
+    def test_process_ifacl_value(self):
+        controller_mock = mocks.MockTemplateController(user_acl={"entity.action": 20})
+        request = mocks.MockRequest()
+        visitor = mocks.MockTemplateVisitor()
+        child_node = mocks.MockTemplateNode()
+        node = mocks.MockTemplateNode(
+            attributes={"permission": "entity.action"}, children=[child_node]
+        )
+
+        process_method = controller.get_process_method(
+            controller_mock, request, "process_ifacl"
+        )
+        process_method(visitor, node)
+
+        self.assertEqual(child_node.accepted, False)
+
+        child_node = mocks.MockTemplateNode()
+        node = mocks.MockTemplateNode(
+            attributes={"permission": "entity.action", "value": 20},
+            children=[child_node],
+        )
+        process_method(visitor, node)
+
+        self.assertEqual(child_node.accepted, True)
+
+    def test_process_ifacl_session_attribute(self):
+        controller_mock = mocks.MockTemplateController(user_acl={"entity.action": 10})
+        request = mocks.MockRequest()
+        visitor = mocks.MockTemplateVisitor()
+        node = mocks.MockTemplateNode(
+            attributes={
+                "permission": "entity.action",
+                "session_attribute": "admin_acl",
+            }
+        )
+
+        process_method = controller.get_process_method(
+            controller_mock, request, "process_ifacl"
+        )
+        process_method(visitor, node)
+
+        self.assertEqual(controller_mock._session_attribute_names, ["admin_acl"])
+
+    def test_process_ifacl_no_visit_childs(self):
+        controller_mock = mocks.MockTemplateController(user_acl={"entity.action": 10})
+        request = mocks.MockRequest()
+        visitor = mocks.MockTemplateVisitor(visit_childs=False)
+        child_node = mocks.MockTemplateNode()
+        node = mocks.MockTemplateNode(
+            attributes={"permission": "entity.action"}, children=[child_node]
+        )
+
+        process_method = controller.get_process_method(
+            controller_mock, request, "process_ifacl"
+        )
+        process_method(visitor, node)
+
+        self.assertEqual(child_node.accepted, False)
+
+    def test_process_ifaclp(self):
+        controller_mock = mocks.MockTemplateController(user_acl={"entity.action": 10})
+        request = mocks.MockRequest()
+        visitor = mocks.MockTemplateVisitor()
+        child_node = mocks.MockTemplateNode()
+        node = mocks.MockTemplateNode(
+            attributes={"permission": "entity.action"}, children=[child_node]
+        )
+
+        process_method = controller.get_process_method(
+            controller_mock, request, "process_ifaclp"
+        )
+        process_method(visitor, node)
+
+        self.assertEqual(child_node.accepted, True)
+
+    def test_process_ifaclp_denied(self):
+        controller_mock = mocks.MockTemplateController(user_acl={"entity.action": 10})
+        request = mocks.MockRequest()
+        visitor = mocks.MockTemplateVisitor()
+        child_node = mocks.MockTemplateNode()
+        node = mocks.MockTemplateNode(
+            attributes={"permission": "entity.other"}, children=[child_node]
+        )
+
+        process_method = controller.get_process_method(
+            controller_mock, request, "process_ifaclp"
+        )
+        process_method(visitor, node)
+
+        self.assertEqual(child_node.accepted, False)
+
+    def test_process_ifnotacl(self):
+        controller_mock = mocks.MockTemplateController(user_acl={"entity.action": 10})
+        request = mocks.MockRequest()
+        visitor = mocks.MockTemplateVisitor()
+        child_node = mocks.MockTemplateNode()
+        node = mocks.MockTemplateNode(
+            attributes={"permission": "entity.other", "value": 10},
+            children=[child_node],
+        )
+
+        process_method = controller.get_process_method(
+            controller_mock, request, "process_ifnotacl"
+        )
+        process_method(visitor, node)
+
+        self.assertEqual(child_node.accepted, True)
+
+    def test_process_ifnotacl_granted(self):
+        controller_mock = mocks.MockTemplateController(user_acl={"entity.action": 10})
+        request = mocks.MockRequest()
+        visitor = mocks.MockTemplateVisitor()
+        child_node = mocks.MockTemplateNode()
+        node = mocks.MockTemplateNode(
+            attributes={"permission": "entity.action", "value": 10},
+            children=[child_node],
+        )
+
+        process_method = controller.get_process_method(
+            controller_mock, request, "process_ifnotacl"
+        )
+        process_method(visitor, node)
+
+        self.assertEqual(child_node.accepted, False)
 
 
 class ExceptionsTestCase(colony.ColonyTestCase):

--- a/mvc/src/mvc_utils/test.py
+++ b/mvc/src/mvc_utils/test.py
@@ -33,6 +33,7 @@ import colony
 from . import utils
 from . import mocks
 from . import system
+from . import controller
 from . import exceptions
 
 
@@ -47,6 +48,7 @@ class MVCUtilsTest(colony.Test):
             MVCUtilsBaseTestCase,
             RawModelTestCase,
             ValidatedDecoratorTestCase,
+            TemplateFileACLTestCase,
             ExceptionsTestCase,
         )
 
@@ -325,6 +327,70 @@ class ValidatedDecoratorTestCase(colony.ColonyTestCase):
             return "success"
 
         self.assertEqual(my_action.__name__, "my_action")
+
+
+class TemplateFileACLTestCase(colony.ColonyTestCase):
+    @staticmethod
+    def get_description():
+        return "Template File ACL test case"
+
+    def test_process_template_file(self):
+        controller_mock = mocks.MockTemplateController(user_acl={"entity.action": 10})
+        request = mocks.MockRequest()
+        template_file = mocks.MockTemplateFile()
+
+        result = controller.process_template_file(
+            controller_mock, request, template_file
+        )
+
+        self.assertEqual(result, "processed")
+        method_names = [name for name, _method in template_file.process_methods_list]
+        self.assertTrue("process_ifacl" in method_names)
+        self.assertTrue("process_ifnotacl" in method_names)
+        self.assertTrue("acl" in template_file.assigns)
+
+    def test_acl_function(self):
+        controller_mock = mocks.MockTemplateController(user_acl={"entity.action": 10})
+        template_file = mocks.MockTemplateFile()
+        controller.process_template_file(
+            controller_mock, mocks.MockRequest(), template_file
+        )
+
+        acl = template_file.assigns["acl"]
+        self.assertEqual(acl("entity.action"), True)
+        self.assertEqual(acl("entity.other"), False)
+
+    def test_acl_function_wildcard(self):
+        controller_mock = mocks.MockTemplateController(user_acl={"*": 10})
+        template_file = mocks.MockTemplateFile()
+        controller.process_template_file(
+            controller_mock, mocks.MockRequest(), template_file
+        )
+
+        acl = template_file.assigns["acl"]
+        self.assertEqual(acl("entity.action"), True)
+        self.assertEqual(acl("other.action"), True)
+
+    def test_acl_function_value(self):
+        controller_mock = mocks.MockTemplateController(user_acl={"entity.action": 20})
+        template_file = mocks.MockTemplateFile()
+        controller.process_template_file(
+            controller_mock, mocks.MockRequest(), template_file
+        )
+
+        acl = template_file.assigns["acl"]
+        self.assertEqual(acl("entity.action"), False)
+        self.assertEqual(acl("entity.action", 20), True)
+
+    def test_acl_function_no_session(self):
+        controller_mock = mocks.MockTemplateController(user_acl=None)
+        template_file = mocks.MockTemplateFile()
+        controller.process_template_file(
+            controller_mock, mocks.MockRequest(), template_file
+        )
+
+        acl = template_file.assigns["acl"]
+        self.assertEqual(acl("entity.action"), False)
 
 
 class ExceptionsTestCase(colony.ColonyTestCase):


### PR DESCRIPTION
## Summary

Adds a small `acl(name, value=10)` function to the template processing context, closed over the current request, enabling ACL permission checks with the modern template syntax (and the classic one) through the engine's function call support:

```text
{% if acl("entity.action") %}...{% endif %}
{% if not acl("entity.action") %}...{% endif %}          # replaces ifnotacl
{% if acl("entity.action", 20) %}...{% endif %}          # threshold variant
${if item=acl("entity.action")}...${/if}
```

## Implementation

- The function is assigned in `process_template_file`, the single template rendering path, right where the classic `ifacl`/`ifaclp`/`ifnotacl` process methods are attached
- Semantics mirror `__process_ifacl` exactly: same session attribute (`user_acl`), same `process_acl_values` evaluation (exact key plus `*` wildcard) and the same allow threshold default
- Template files are parsed per render (no caching), so the request bound closure carries no cross-request state
- Included partials inherit the parent's global map, so the function is available in every included template

## Testing

- New `TemplateFileACLTestCase` with the matching `MockTemplateFile`/`MockTemplateController` mocks covering the assignment, exact grants, wildcard, threshold and session-less denial
- Full `mvc_utils` test module passes (44 tests)
- Verified end-to-end against the template engine with a 12-case render matrix (both syntaxes, three permission profiles)

Closes #27